### PR TITLE
Fix failing testCreateItemWithMissingType.

### DIFF
--- a/test/ItemTest.php
+++ b/test/ItemTest.php
@@ -8,7 +8,7 @@ class ItemTest extends LibraryTestCase {
 
   /**
    * @expectedException Exception
-   * @expectedExceptionMessage Invalid value type
+   * @expectedExceptionMessage Missing required field: type
    */
   public function testCreateItemWithMissingType() {
     $item = new Item($this->library, null);


### PR DESCRIPTION
Currently the first test is failing because it watches for the wrong Exception.

```
1) ItemTest::testCreateItemWithMissingType
Failed asserting that exception message 'Missing required field: type' contains 'Invalid value type'.
```

`null` is not an invalid value as `Item#__set` [automatically converts it](https://github.com/bastianallgeier/library/blob/5dca071ad303fa02d3497f1abc6ddfe5d33a3768/library/item.php#L109-L110) to an empty string (`''`). The required fields check trips over a missing type, as expected, so there is no lack of exception. It just isn’t the one you are testing for.

This fixes the PHPUnit test to listen for the correct exception.
